### PR TITLE
Assign codeowners to tm-browser

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-browser


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-browser as codeowners.